### PR TITLE
Upgrade the Logic to use reflection and more mapper possibilities

### DIFF
--- a/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/DTOExtraField.java
+++ b/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/DTOExtraField.java
@@ -1,0 +1,13 @@
+package org.lets_do_this_the_easy_way.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({})
+public @interface DTOExtraField {
+    String name();
+    String type();
+    String defaultValue() default "";
+}

--- a/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/DTOExtraFields.java
+++ b/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/DTOExtraFields.java
@@ -1,11 +1,13 @@
-package org.lets_do_this_the_easy_way;
+package org.lets_do_this_the_easy_way.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.SOURCE)
-public @interface ExcludeFromDTO {
+@Target(ElementType.TYPE)
+public @interface DTOExtraFields {
+    DTOExtraField[] value();
 }
+

--- a/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/DTOName.java
+++ b/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/DTOName.java
@@ -1,0 +1,12 @@
+package org.lets_do_this_the_easy_way.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.FIELD)
+public @interface DTOName {
+    String name();
+}

--- a/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/ExcludeFromDTO.java
+++ b/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/ExcludeFromDTO.java
@@ -1,11 +1,11 @@
-package org.lets_do_this_the_easy_way;
+package org.lets_do_this_the_easy_way.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.TYPE)
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.SOURCE)
-public @interface ToDTO {
+public @interface ExcludeFromDTO {
 }

--- a/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/ToDTO.java
+++ b/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/annotations/ToDTO.java
@@ -1,0 +1,11 @@
+package org.lets_do_this_the_easy_way.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ToDTO {
+}

--- a/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/codeGeneration/DTOProcessor.java
+++ b/entity-to-dto-core/src/main/java/org/lets_do_this_the_easy_way/codeGeneration/DTOProcessor.java
@@ -108,14 +108,20 @@ public class DTOProcessor extends AbstractProcessor {
             // Field reflection logic
             for (Element field : fields) {
                 String fieldName = field.getSimpleName().toString();
+                String fieldNameDTO = field.getSimpleName().toString();
+
+                if (field.getAnnotation(DTOName.class) != null) {
+                    DTOName dtoName = field.getAnnotation(DTOName.class);
+                    fieldNameDTO = dtoName.name();
+                }
 
                 writer.printf("            Field %sfield = %s.class.getDeclaredField(\"%s\");%n", fieldName, oldClassName, fieldName);
                 writer.printf("            %sfield.setAccessible(true);%n", fieldName);
                 writer.printf("            Object %sValue = %sfield.get(%s);%n%n", fieldName, fieldName, oldClassName);
 
-                writer.printf("            Field %sDTO = %s.class.getDeclaredField(\"%s\");%n", fieldName, dtoClassName, fieldName);
-                writer.printf("            %sDTO.setAccessible(true);%n", fieldName);
-                writer.printf("            %sDTO.set(dto, %sValue);%n%n", fieldName, fieldName);
+                writer.printf("            Field %sDTO = %s.class.getDeclaredField(\"%s\");%n", fieldNameDTO, dtoClassName, fieldNameDTO);
+                writer.printf("            %sDTO.setAccessible(true);%n", fieldNameDTO);
+                writer.printf("            %sDTO.set(dto, %sValue);%n%n", fieldNameDTO, fieldName);
             }
 
             // Catch block and return
@@ -124,7 +130,7 @@ public class DTOProcessor extends AbstractProcessor {
             writer.println("        }");
             writer.println();
             writer.println("        return dto;");
-            writer.println("    }");
+            writer.println("    }\n");
 
             //Next mapper
             writer.printf("    public static List<%s> mapTo%s(List<%s> %sList) {%n", dtoClassName, dtoClassName, oldClassName, oldClassName);
@@ -137,19 +143,20 @@ public class DTOProcessor extends AbstractProcessor {
             // Field reflection logic
             for (Element field : fields) {
                 String fieldName = field.getSimpleName().toString();
+                String fieldNameDTO = field.getSimpleName().toString();
 
-                if (element.getAnnotation(DTOName.class) != null) {
-                    DTOName dtoName = element.getAnnotation(DTOName.class);
-                    fieldName = dtoName.name();
+                if (field.getAnnotation(DTOName.class) != null) {
+                    DTOName dtoName = field.getAnnotation(DTOName.class);
+                    fieldNameDTO = dtoName.name();
                 }
 
                 writer.printf("            Field %sfield = %s.class.getDeclaredField(\"%s\");%n", fieldName, oldClassName, fieldName);
                 writer.printf("            %sfield.setAccessible(true);%n", fieldName);
                 writer.printf("            Object %sValue = %sfield.get(entity);%n%n", fieldName, fieldName);
 
-                writer.printf("            Field %sDTO = %s.class.getDeclaredField(\"%s\");%n", fieldName, dtoClassName, fieldName);
-                writer.printf("            %sDTO.setAccessible(true);%n", fieldName);
-                writer.printf("            %sDTO.set(dto, %sValue);%n%n", fieldName, fieldName);
+                writer.printf("            Field %sDTO = %s.class.getDeclaredField(\"%s\");%n", fieldNameDTO, dtoClassName, fieldNameDTO);
+                writer.printf("            %sDTO.setAccessible(true);%n", fieldNameDTO);
+                writer.printf("            %sDTO.set(dto, %sValue);%n%n", fieldNameDTO, fieldName);
             }
             writer.println("            dtoList.add(dto);");
 
@@ -172,14 +179,20 @@ public class DTOProcessor extends AbstractProcessor {
             // Field reflection logic
             for (Element field : fields) {
                 String fieldName = field.getSimpleName().toString();
+                String fieldNameDTO = field.getSimpleName().toString();
+
+                if (field.getAnnotation(DTOName.class) != null) {
+                    DTOName dtoName = field.getAnnotation(DTOName.class);
+                    fieldNameDTO = dtoName.name();
+                }
 
                 writer.printf("            Field %sfield = %s.class.getDeclaredField(\"%s\");%n", fieldName, oldClassName, fieldName);
                 writer.printf("            %sfield.setAccessible(true);%n", fieldName);
                 writer.printf("            Object %sValue = %sfield.get(%sArray[i]);%n%n", fieldName, fieldName, oldClassName);
 
-                writer.printf("            Field %sDTO = %s.class.getDeclaredField(\"%s\");%n", fieldName, dtoClassName, fieldName);
-                writer.printf("            %sDTO.setAccessible(true);%n", fieldName);
-                writer.printf("            %sDTO.set(dto, %sValue);%n%n", fieldName, fieldName);
+                writer.printf("            Field %sDTO = %s.class.getDeclaredField(\"%s\");%n", fieldNameDTO, dtoClassName, fieldNameDTO);
+                writer.printf("            %sDTO.setAccessible(true);%n", fieldNameDTO);
+                writer.printf("            %sDTO.set(dto, %sValue);%n%n", fieldNameDTO, fieldName);
             }
             writer.println("            dtoArray[i] = dto;");
 
@@ -200,14 +213,20 @@ public class DTOProcessor extends AbstractProcessor {
 
             for (Element field : fields) {
                 String fieldName = field.getSimpleName().toString();
+                String fieldNameDTO = field.getSimpleName().toString();
+
+                if (field.getAnnotation(DTOName.class) != null) {
+                    DTOName dtoName = field.getAnnotation(DTOName.class);
+                    fieldNameDTO = dtoName.name();
+                }
 
                 writer.printf("            Field %sField = %s.class.getDeclaredField(\"%s\");%n", fieldName, dtoClassName, fieldName);
                 writer.printf("            %sField.setAccessible(true);%n", fieldName);
                 writer.printf("            Object %sValue = %sField.get(dto);%n%n", fieldName, fieldName);
 
-                writer.printf("            Field %sEntityField = %s.class.getDeclaredField(\"%s\");%n", fieldName, oldClassName, fieldName);
-                writer.printf("            %sEntityField.setAccessible(true);%n", fieldName);
-                writer.printf("            %sEntityField.set(entity, %sValue);%n%n", fieldName, fieldName);
+                writer.printf("            Field %sEntityField = %s.class.getDeclaredField(\"%s\");%n", fieldNameDTO, oldClassName, fieldNameDTO);
+                writer.printf("            %sEntityField.setAccessible(true);%n", fieldNameDTO);
+                writer.printf("            %sEntityField.set(entity, %sValue);%n%n", fieldNameDTO, fieldName);
             }
 
             writer.println("        } catch (NoSuchFieldException | IllegalAccessException e) {");
@@ -228,14 +247,20 @@ public class DTOProcessor extends AbstractProcessor {
 
             for (Element field : fields) {
                 String fieldName = field.getSimpleName().toString();
+                String fieldNameDTO = field.getSimpleName().toString();
+
+                if (field.getAnnotation(DTOName.class) != null) {
+                    DTOName dtoName = field.getAnnotation(DTOName.class);
+                    fieldNameDTO = dtoName.name();
+                }
 
                 writer.printf("                Field %sField = %s.class.getDeclaredField(\"%s\");%n", fieldName, dtoClassName, fieldName);
                 writer.printf("                %sField.setAccessible(true);%n", fieldName);
                 writer.printf("                Object %sValue = %sField.get(dto);%n%n", fieldName, fieldName);
 
-                writer.printf("                Field %sEntityField = %s.class.getDeclaredField(\"%s\");%n", fieldName, oldClassName, fieldName);
-                writer.printf("                %sEntityField.setAccessible(true);%n", fieldName);
-                writer.printf("                %sEntityField.set(entity, %sValue);%n%n", fieldName, fieldName);
+                writer.printf("                Field %sEntityField = %s.class.getDeclaredField(\"%s\");%n", fieldNameDTO, oldClassName, fieldNameDTO);
+                writer.printf("                %sEntityField.setAccessible(true);%n", fieldNameDTO);
+                writer.printf("                %sEntityField.set(entity, %sValue);%n%n", fieldNameDTO, fieldName);
             }
 
             writer.println("                entityList.add(entity);");
@@ -257,14 +282,20 @@ public class DTOProcessor extends AbstractProcessor {
 
             for (Element field : fields) {
                 String fieldName = field.getSimpleName().toString();
+                String fieldNameDTO = field.getSimpleName().toString();
+
+                if (field.getAnnotation(DTOName.class) != null) {
+                    DTOName dtoName = field.getAnnotation(DTOName.class);
+                    fieldNameDTO = dtoName.name();
+                }
 
                 writer.printf("                Field %sField = %s.class.getDeclaredField(\"%s\");%n", fieldName, dtoClassName, fieldName);
                 writer.printf("                %sField.setAccessible(true);%n", fieldName);
                 writer.printf("                Object %sValue = %sField.get(dtoArray[i]);%n%n", fieldName, fieldName);
 
-                writer.printf("                Field %sEntityField = %s.class.getDeclaredField(\"%s\");%n", fieldName, oldClassName, fieldName);
-                writer.printf("                %sEntityField.setAccessible(true);%n", fieldName);
-                writer.printf("                %sEntityField.set(entity, %sValue);%n%n", fieldName, fieldName);
+                writer.printf("                Field %sEntityField = %s.class.getDeclaredField(\"%s\");%n", fieldNameDTO, oldClassName, fieldNameDTO);
+                writer.printf("                %sEntityField.setAccessible(true);%n", fieldNameDTO);
+                writer.printf("                %sEntityField.set(entity, %sValue);%n%n", fieldNameDTO, fieldName);
             }
 
             writer.println("                entityArray[i] = entity;");

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
@@ -1,11 +1,13 @@
 package org.lets_do_this_the_easy_way;
 
 
-import org.lets_do_this_the_easy_way.annotations.DTOName;
-import org.lets_do_this_the_easy_way.annotations.ExcludeFromDTO;
-import org.lets_do_this_the_easy_way.annotations.ToDTO;
+import org.lets_do_this_the_easy_way.annotations.*;
 
 @ToDTO
+@DTOExtraFields({
+        @DTOExtraField(name = "isAdmin", type = "boolean", defaultValue = "false"),
+        @DTOExtraField(name = "displayName", type = "String")
+})
 public class ExampleUser {
 
     @DTOName(name = "Username")

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
@@ -1,5 +1,9 @@
 package org.lets_do_this_the_easy_way;
 
+
+import org.lets_do_this_the_easy_way.annotations.ExcludeFromDTO;
+import org.lets_do_this_the_easy_way.annotations.ToDTO;
+
 @ToDTO
 public class ExampleUser {
 

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
@@ -8,6 +8,7 @@ import org.lets_do_this_the_easy_way.annotations.ToDTO;
 @ToDTO
 public class ExampleUser {
 
+    @DTOName(name = "Username")
     private String username;
 
     @DTOName(name = "age_in_years")

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
@@ -18,4 +18,7 @@ public class ExampleUser {
         this.age = age;
         this.password = password;
     }
+
+    public ExampleUser() {
+    }
 }

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
@@ -1,6 +1,7 @@
 package org.lets_do_this_the_easy_way;
 
 
+import org.lets_do_this_the_easy_way.annotations.DTOName;
 import org.lets_do_this_the_easy_way.annotations.ExcludeFromDTO;
 import org.lets_do_this_the_easy_way.annotations.ToDTO;
 
@@ -8,6 +9,8 @@ import org.lets_do_this_the_easy_way.annotations.ToDTO;
 public class ExampleUser {
 
     private String username;
+
+    @DTOName(name = "age_in_years")
     private int age;
 
     @ExcludeFromDTO

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/ExampleUser.java
@@ -4,23 +4,6 @@ package org.lets_do_this_the_easy_way;
 public class ExampleUser {
 
     private String username;
-
-    public int getAge() {
-        return age;
-    }
-
-    public void setAge(int age) {
-        this.age = age;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
     private int age;
 
     @ExcludeFromDTO

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/Main.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/Main.java
@@ -1,6 +1,10 @@
 package org.lets_do_this_the_easy_way;
 
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class Main {
     public static void main(String[] args) {
 
@@ -10,5 +14,30 @@ public class Main {
 
         System.out.println(JohnDTO.getUsername());
         System.out.println(JohnDTO.getAge());
+
+
+        ExampleUser user1 = new ExampleUser("alice", 30, "secret123");
+        ExampleUser user2 = new ExampleUser("bob", 25, "hunter2");
+
+        List<ExampleUser> usersList = new ArrayList<>();
+        usersList.add(user1);
+        usersList.add(user2);
+
+        List<ExampleUserDTO> dtosList = ExampleUserDTOMapper.mapToExampleUserDTO(usersList);
+
+        dtosList.forEach(dto -> System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge()));
+
+
+
+        ExampleUser[] usersArray = {
+                new ExampleUser("John", 30, "secret123"),
+                new ExampleUser("JOHN CENA", 25, "hunter2")
+        };
+
+        ExampleUserDTO[] dtosArray = ExampleUserDTOMapper.mapToExampleUserDTO(usersArray);
+
+        Arrays.stream(dtosArray).forEach(dto ->
+                System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge())
+        );
     }
 }

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/Main.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/Main.java
@@ -12,8 +12,14 @@ public class Main {
 
         ExampleUserDTO JohnDTO = ExampleUserDTOMapper.mapToExampleUserDTO(John);
 
+        //These Fields were added to the DTO via the @DTOExtraFields annotation
+        JohnDTO.setIsAdmin(true);
+        JohnDTO.setDisplayName("Doe, John");
+
         System.out.println(JohnDTO.getUsername());
         System.out.println(JohnDTO.getAge_in_years());
+        System.out.println("is Admin: " + JohnDTO.getIsAdmin());
+        System.out.println("Display name: " + JohnDTO.getDisplayName());
 
 
         ExampleUser user1 = new ExampleUser("alice", 30, "secret123");
@@ -26,7 +32,6 @@ public class Main {
         List<ExampleUserDTO> dtosList = ExampleUserDTOMapper.mapToExampleUserDTO(usersList);
 
         dtosList.forEach(dto -> System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge_in_years()));
-
 
 
         ExampleUser[] usersArray = {

--- a/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/Main.java
+++ b/entity-to-dto-demo/src/main/java/org/lets_do_this_the_easy_way/Main.java
@@ -13,7 +13,7 @@ public class Main {
         ExampleUserDTO JohnDTO = ExampleUserDTOMapper.mapToExampleUserDTO(John);
 
         System.out.println(JohnDTO.getUsername());
-        System.out.println(JohnDTO.getAge());
+        System.out.println(JohnDTO.getAge_in_years());
 
 
         ExampleUser user1 = new ExampleUser("alice", 30, "secret123");
@@ -25,7 +25,7 @@ public class Main {
 
         List<ExampleUserDTO> dtosList = ExampleUserDTOMapper.mapToExampleUserDTO(usersList);
 
-        dtosList.forEach(dto -> System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge()));
+        dtosList.forEach(dto -> System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge_in_years()));
 
 
 
@@ -37,7 +37,7 @@ public class Main {
         ExampleUserDTO[] dtosArray = ExampleUserDTOMapper.mapToExampleUserDTO(usersArray);
 
         Arrays.stream(dtosArray).forEach(dto ->
-                System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge())
+                System.out.println("Username: " + dto.getUsername() + ", Age: " + dto.getAge_in_years())
         );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lets_do_this_the_easy_way</groupId>


### PR DESCRIPTION
This PR introduces a new feature to the code generation system that enables support for the @DTOExtraFields annotation. This enhancement allows users to declare additional fields for their generated DTOs, which are not present in the source class, using the @DTOExtraField annotation array.

These additional fields are now correctly:

Generated in the DTO class file

Included in getter/setter generation

Populated with default values (if specified) during mapping

Fully handled by the DTO-to-Entity and Entity-to-DTO reflection mappers

Motivation
The goal was to make DTOs more flexible and decoupled from the original class structure. In scenarios where extra metadata or computed fields are needed (e.g., isAdmin, displayName, etc.), users can now easily declare these in a clean and declarative way using annotations—no need to modify the original entity.

Key Changes
Added reflection-based logic to detect and process @DTOExtraFields on classes.

DTO class generation logic now appends these extra fields.

Mapper logic uses default values for these fields where applicable.

Improved overall modularity of field-handling logic (to support both real fields and virtual ones).